### PR TITLE
Fix form data population for manual harvests

### DIFF
--- a/PRL/prl_joai_admin/prl_joai_admin.py
+++ b/PRL/prl_joai_admin/prl_joai_admin.py
@@ -211,7 +211,7 @@ def main():
                         'shIntervalGranularity': 'days',
                         'shRunAtTime':  row['Harvest at time T'],
                         'shDir': 'custom',
-                        'shHarvestDir': 'harvest/{}/{}'.format(urlparse(row['Repository base URL']).netloc, collection_dir),
+                        'shHarvestDir': '/joai/data/{}/{}'.format(urlparse(row['Repository base URL']).netloc, collection_dir),
                         's': '+',
                         'shDontZipFiles': 'true',
                         'shSet': 'split' if collection_dir == '' else 'dontsplit'

--- a/PRL/prl_joai_admin/prl_joai_admin.py
+++ b/PRL/prl_joai_admin/prl_joai_admin.py
@@ -206,16 +206,19 @@ def main():
                         'shBaseURL': row['Repository base URL'],
                         'shSetSpec': row['OAI-PMH SetSpec'],
                         'shMetadataPrefix': 'oai_dc',
-                        'shEnabledDisabled': 'enabled',
-                        'shHarvestingInterval': row['Harvest every X days'],
+                        'shHarvestingInterval': row['Harvest every X days'] or '',
                         'shIntervalGranularity': 'days',
-                        'shRunAtTime':  row['Harvest at time T'],
+                        'shRunAtTime':  row['Harvest at time T'] or '',
                         'shDir': 'custom',
                         'shHarvestDir': '/joai/data/{}/{}'.format(urlparse(row['Repository base URL']).netloc, collection_dir),
                         's': '+',
                         'shDontZipFiles': 'true',
                         'shSet': 'split' if collection_dir == '' else 'dontsplit'
                     }
+
+                    if row['Harvest every X days'] or row['Harvest at time T']:
+                        request_payload['shEnabledDisabled'] = 'enabled'
+
                     r = s.post(oai_submit_args['harvester_admin_url'],
                             data=request_payload,
                             cookies=s.cookies


### PR DESCRIPTION
A while back I discovered that the population of form data for unscheduled (manual) harvests was broken, but never pushed the changes from my local.